### PR TITLE
fixed dldi size

### DIFF
--- a/source/arm9/dldi/dldi_stub.s
+++ b/source/arm9/dldi/dldi_stub.s
@@ -42,9 +42,9 @@ dldi_start:
 	.word	0xBF8DA5ED		@ Magic number to identify this region
 	.asciz	" Chishm"		@ Identifying Magic string (8 bytes with null terminator)
 	.byte	0x01			@ Version number
-	.byte	0x0F	@32KiB	@ Log [base-2] of the size of this driver in bytes.
+	.byte	0x0E	@16KiB	@ Log [base-2] of the size of this driver in bytes.
 	.byte	0x00			@ Sections to fix
-	.byte 	0x0F	@32KiB	@ Log [base-2] of the allocated space in bytes.
+	.byte 	0x0E	@16KiB	@ Log [base-2] of the allocated space in bytes.
 	
 @---------------------------------------------------------------------------------
 @ Text identifier - can be anything up to 47 chars + terminating null -- 16 bytes


### PR DESCRIPTION
the driver size was changed in commit c9668aa8f47bd41400f485b8a9a728b517a1174d but not the info how big the allocated space is.